### PR TITLE
Fix DataStore limits after official docs drift (#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Content
+
+- Re-verified DataStore limits against official docs: experience request bases are `300 + concurrentUsers × N` (not 250/10/100), storage is `500 MB + 1 MB × lifetime users` measured on compressed latest-version size, and Open Cloud v2 Data Store traffic shares the experience request budget with game servers. Legacy Open Cloud v1 keeps separate fixed limits after July 29, 2026.
+
 ### Site
 
 - Moved the documentation site from GitHub Pages (`nonlooped.github.io/roblox-suite`) to Vercel at [roblox-suite.vercel.app](https://roblox-suite.vercel.app/), with root-base URLs and updated sitemap/robots canonicals.

--- a/catalog.json
+++ b/catalog.json
@@ -219,7 +219,7 @@
         {
           "label": "Error codes & limits",
           "url": "https://create.roblox.com/docs/cloud-services/data-stores/error-codes-and-limits",
-          "verified_at": "2026-07-16"
+          "verified_at": "2026-07-20"
         },
         {
           "label": "Best practices",
@@ -247,7 +247,7 @@
           }
         ]
       },
-      "last_changed_at": "2026-07-16"
+      "last_changed_at": "2026-07-20"
     },
     {
       "slug": "roblox-user-interfaces",
@@ -514,6 +514,16 @@
           "label": "Rate limits",
           "url": "https://create.roblox.com/docs/en-us/cloud/reference/rate-limits",
           "verified_at": "2026-07-16"
+        },
+        {
+          "label": "Data store error codes & limits (v2 shared budgets)",
+          "url": "https://create.roblox.com/docs/cloud-services/data-stores/error-codes-and-limits",
+          "verified_at": "2026-07-20"
+        },
+        {
+          "label": "Open Cloud Data Stores throttling (legacy v1)",
+          "url": "https://create.roblox.com/docs/cloud/guides/data-stores/throttling",
+          "verified_at": "2026-07-20"
         }
       ],
       "risk": "critical",
@@ -527,7 +537,7 @@
           }
         ]
       },
-      "last_changed_at": "2026-07-16"
+      "last_changed_at": "2026-07-20"
     },
     {
       "slug": "roblox-teleport",

--- a/roblox-datastores/SKILL.md
+++ b/roblox-datastores/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: roblox-datastores
 description: "Safety-oriented Roblox DataStore guidance for reducing data loss, throttling, races, and quota exhaustion. Covers DataStore vs OrderedDataStore, UpdateAsync for atomic writes, versioning and metadata for recovery, budgets and rate limits, player profile and session-locking patterns, leaderboards, RTBF, and integration with Open Cloud. Use for any persistent player data, stats, inventory, settings, or cross-server state."
-last_reviewed: 2026-07-16
+last_reviewed: 2026-07-20
 ---
 
 # roblox-datastores
@@ -136,7 +136,7 @@ See references/versioning-metadata-recovery.md (for listing, caching, serializat
 
 ### Limits, quotas, throttling, and budgets (you *must* respect these)
 
-There are **experience-level** limits (scale with concurrent users across the whole experience) and **per-server** limits (configurable via DataStoreService:SetRateLimitForRequestType).
+There are **experience-level** limits (scale with concurrent users across the whole experience) and **per-server** limits (configurable via DataStoreService:SetRateLimitForRequestType). Experience-level pools are **shared between game servers and Open Cloud v2** Data Store traffic — bulk external jobs can throttle live players (and vice versa).
 
 UpdateAsync counts against *both* read and write budgets.
 
@@ -144,11 +144,11 @@ Use DataStoreService:GetRequestBudgetForRequestType(Enum.DataStoreRequestType.XX
 
 Queues exist (size 30); when full, you get throttle errors (301-306 range or the newer *Throttled errors).
 
-Full tables of every error code (101 KeyNameEmpty ... through all the *ExperienceThrottled and *GameServerThrottled variants) plus server-side errors are in references/limits-quotas-throttling-error-codes.md .
+Full tables of every error code (101 KeyNameEmpty ... through all the *ExperienceThrottled and *GameServerThrottled variants), experience formulas (base 300 + concurrentUsers × N), and server-side errors are in references/limits-quotas-throttling-error-codes.md .
 
 Observability dashboard (Creator Hub → Monitoring → Data Stores) shows real-time request counts by API/status, quota usage percentages, storage bytes vs limit.
 
-Data Stores Manager shows total size vs storage limit (based on lifetime users), per-DS key counts, etc.
+Data Stores Manager shows total size vs storage limit (`500 MB + 1 MB × lifetime users`, measured as compressed latest-version size), per-DS key counts, etc. Do not pre-compress values before writing.
 
 **Pro tip:** Call SetRateLimitForRequestType early in server init (once per type) to raise limits for migration scripts or busy servers. Base + (perPlayer * numPlayers). Constraints per type are documented.
 

--- a/roblox-datastores/references/best-practices-and-gotchas.md
+++ b/roblox-datastores/references/best-practices-and-gotchas.md
@@ -1,5 +1,5 @@
 ---
-last_reviewed: 2026-06-17
+last_reviewed: 2026-07-20
 ---
 
 # Best Practices and Common Gotchas
@@ -14,8 +14,10 @@ Synthesized from the official "Best practices for data stores" page + all the er
 
 ## Optimization & Quota Hygiene
 
-- Monitor constantly: Data Stores Dashboard (Creator Hub Monitoring) for request volume, status codes, and quota % usage. Data Stores Manager for actual stored size vs lifetime-user-based limit.
+- Monitor constantly: Data Stores Dashboard (Creator Hub Monitoring) for request volume, status codes, and quota % usage. Data Stores Manager for actual stored size vs lifetime-user-based limit (`500 MB + 1 MB × lifetime users`, compressed latest-version size).
 - Set up notifications for approaching or breaching storage limits.
+- Store normal serializable tables; do **not** pre-compress values — Roblox compresses on write and measures quota on compressed size.
+- Rate-limit Open Cloud v2 Data Store clients separately; they share the experience request budget with live servers.
 - Delete aggressively after testing or events: use Manager "Mark for Deletion" (cooldown; keys can be restored via `UpdateAsync` from the Engine API or `UpdateDataStoreEntry` from Open Cloud during the cooldown), Batch Processor CLI, or Open Cloud bulk delete.
 - Prefer versioning + restore over "save a new key for every version".
 - Use MemoryStores for anything that does not truly need to survive server restarts or long player absences.

--- a/roblox-datastores/references/limits-quotas-throttling-error-codes.md
+++ b/roblox-datastores/references/limits-quotas-throttling-error-codes.md
@@ -1,15 +1,17 @@
 ---
-last_reviewed: 2026-07-16
+last_reviewed: 2026-07-20
 ---
 
 # Limits, Quotas, Throttling, and Error Codes
 
 **Primary source:** https://create.roblox.com/docs/cloud-services/data-stores/error-codes-and-limits (contains the exhaustive tables this document summarizes and expands with usage advice).
 
+Open Cloud Data Stores v2 rate limits live on the same page under Access limits (shared with the Engine API). Legacy Open Cloud v1 endpoint limits remain on https://create.roblox.com/docs/cloud/guides/data-stores/throttling and apply only to `/datastores/v1/` and `/ordered-data-stores/v1/` paths after July 29, 2026.
+
 ## Why This Matters
 
 Data stores are a shared cloud resource. Roblox protects the service (and your experience) with multiple layers of limits:
-- Experience-level quotas (scale with total concurrent users across all servers of the universe).
+- Experience-level quotas (scale with total concurrent users across all servers of the universe). **Game servers and Open Cloud share this budget** — external traffic can throttle in-experience usage and vice versa.
 - Per-game-server limits (you can raise these with `DataStoreService:SetRateLimitForRequestType` during server initialization).
 - Per-key throttling in some cases.
 - Hard queue sizes (when queues of 30 fill, requests are dropped with specific throttle errors).
@@ -20,21 +22,26 @@ Exceeding causes dropped requests, errors in the 301+ range (or the more modern 
 
 ## Experience-Level Limits (formulas)
 
-These are shared across the entire experience.
+These are shared across the entire experience (in-engine APIs **and** Open Cloud v2 Data Store endpoints for the matching request type).
 
 ### Standard Data Stores
-- **Read** (GetAsync, GetVersionAsync, GetVersionAtTimeAsync, read portion of UpdateAsync): 250 + concurrentUsers × 40 per minute
-- **Write** (SetAsync, IncrementAsync, write portion of UpdateAsync): 250 + concurrentUsers × 20 per minute
-- **List** (ListDataStoresAsync, ListKeysAsync, ListVersionsAsync): 10 + concurrentUsers × 2 per minute
-- **Remove**: 100 + concurrentUsers × 40 per minute
+- **Read** (GetAsync, GetVersionAsync, GetVersionAtTimeAsync, read portion of UpdateAsync; Open Cloud Get Data Store Entry): 300 + concurrentUsers × 40 per minute
+- **Write** (SetAsync, IncrementAsync, write portion of UpdateAsync; Open Cloud Create/Update/Increment): 300 + concurrentUsers × 20 per minute
+- **List** (ListDataStoresAsync, ListKeysAsync, ListVersionsAsync; Open Cloud List Data Stores / Entries / Revisions): 300 + concurrentUsers × 2 per minute
+- **Remove** (RemoveAsync; Open Cloud Delete Data Store Entry / Delete Data Store / Undelete Data Store): 300 + concurrentUsers × 40 per minute
 
 ### Ordered Data Stores
-- Read (Get + read of Update): 250 + concurrentUsers × 40
-- Write (Set/Increment + write of Update): 250 + concurrentUsers × 20
-- List (GetSortedAsync): 100 + concurrentUsers × 2
-- Remove: 100 + concurrentUsers × 40
+- Read (Get + read of Update; Open Cloud Get Ordered Data Store Entry): 300 + concurrentUsers × 40
+- Write (Set/Increment + write of Update; Open Cloud Create/Update/Increment): 300 + concurrentUsers × 20
+- List (GetSortedAsync; Open Cloud List Ordered Data Store Entries): 300 + concurrentUsers × 2
+- Remove (RemoveAsync; Open Cloud Delete Ordered Data Store Entry): 300 + concurrentUsers × 40
 
 **Important:** UpdateAsync always consumes **both** a read and a write budget for the relevant category.
+
+### Controlling the shared budget
+
+- **Game servers:** use `SetRateLimitForRequestType` + `GetRequestBudgetForRequestType` so individual servers do not exhaust the experience pool.
+- **Open Cloud (external callers):** apply your own limiter (simple fixed spacing of `60 / desired_rpm` seconds, or a leaky-bucket). Official docs include Node.js timeout and leaky-bucket samples on the error-codes page.
 
 ## Server-Level Limits (configurable)
 
@@ -184,15 +191,18 @@ See the full error-codes page for the gigantic tables and the exact messages.
 
 Calculated from lifetime unique users of the experience. Visible in Data Stores Manager as "Total Size" vs "Storage Limit".
 
-**Formula:** `Total latest-version storage limit = 100 MB + (1 MB × lifetime user count)`
+**Formula:** `Total latest-version storage limit = 500 MB + (1 MB × lifetime user count)`
 
-A lifetime user is any user who has joined the experience at least once. Only the latest version of each key counts toward this limit; deleted/replaced keys (even if still accessible through version APIs) do not count. Data stores marked for deletion via Open Cloud continue to count during their 30-day processing period.
+A lifetime user is any user who has joined the experience at least once. Storage usage is measured using the **compressed size** of the latest version of each key — data stores compress before storage. Do **not** pre-compress values yourself; that burns CPU and can reduce the effectiveness of built-in compression (and future schema-based optimizations).
+
+Only the latest version of each key counts toward this limit; deleted keys and superseded versions (still accessible through version APIs during retention) do not count. Data stores marked for deletion via Open Cloud continue to count during their 30-day processing period.
 
 Exceeding → estimated monthly overage costs shown. Can lead to operational pain.
 
 Mitigation (best-practices):
 - Fewer data stores.
 - Larger cohesive objects per key instead of many small keys.
+- Store uncompressed serializable tables; let Roblox compress.
 - Delete test/temporary/seasonal data promptly (Manager "Mark for Deletion" or Batch Processor / Open Cloud).
 - Use MemoryStores for anything that can expire.
 - Monitor the Storage Usage Bytes chart in the observability dashboard.

--- a/roblox-datastores/references/types-of-datastores.md
+++ b/roblox-datastores/references/types-of-datastores.md
@@ -1,5 +1,5 @@
 ---
-last_reviewed: 2026-07-16
+last_reviewed: 2026-07-20
 ---
 
 # Types of Data Stores
@@ -63,19 +63,19 @@ From https://create.roblox.com/docs/cloud-services/data-stores-vs-memory-stores:
 
 Storage quota is per-universe and based on lifetime users.
 
-**Formula:** `Total latest-version storage limit = 100 MB + (1 MB × lifetime user count)`
+**Formula:** `Total latest-version storage limit = 500 MB + (1 MB × lifetime user count)`
 
-Only the latest version of each key counts; older versions and deleted/replaced keys do not count toward this limit (unless a data store is marked for deletion via Open Cloud, in which case it continues to count during its 30-day processing period). Exceeding the limit triggers estimated monthly costs in the Manager and can affect operations.
+Usage is the **compressed** size of each key's latest version. Older versions and deleted/replaced keys do not count toward this limit (unless a data store is marked for deletion via Open Cloud, in which case it continues to count during its 30-day processing period). Exceeding the limit triggers estimated monthly costs in the Manager and can affect operations.
 
 Monitor via:
 - Creator Hub Data Stores Manager (total size, per-DS size/keys, key browser, version history, per-key Revert, mark-for-deletion with cooldown). The Manager's Restore button is for data stores marked for deletion, not for reverting an individual key's value.
 - Observability dashboard (storage bytes, request counts by API and status, quota usage % for read/write/list/remove categories).
 
-See the dedicated references/limits-quotas-throttling-error-codes.md for the full mathematical formulas (experience-level: 250 + concurrentUsers × N for various categories) and per-server defaults/configurable limits.
+See the dedicated references/limits-quotas-throttling-error-codes.md for the full mathematical formulas (experience-level: 300 + concurrentUsers × N for various categories) and per-server defaults/configurable limits.
 
 ## Open Cloud Contrast (for external tools)
 
-The Engine API (inside experiences) is different from the Open Cloud REST Data Stores APIs. The latter require API keys with specific scopes (universe-datastores.*), support bulk/list operations from outside Roblox, and have their own authentication/rate limits. Use Engine for in-experience logic; Open Cloud + Batch Processor for admin tools, migrations, or RTBF processing.
+The Engine API (inside experiences) is different from the Open Cloud REST Data Stores APIs. The latter require API keys with specific scopes (universe-datastores.*), support bulk/list operations from outside Roblox, and use separate authentication. **Request budgets for Open Cloud v2 Data Stores are shared with the in-engine experience limits** (same read/write/list/remove pools). Legacy Open Cloud v1 Data Store endpoints keep their own fixed per-universe limits (see the throttling guide). Use Engine for in-experience logic; Open Cloud + Batch Processor for admin tools, migrations, or RTBF processing — and rate-limit external callers so they do not starve live servers.
 
 **Key takeaway:** Choose the variant deliberately at creation time. You cannot easily convert an OrderedDataStore into a versioned DataStore later without migration code (see best-practices-and-gotchas.md and versioning-metadata-recovery.md for migration and recovery patterns).
 

--- a/roblox-open-cloud/SKILL.md
+++ b/roblox-open-cloud/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: roblox-open-cloud
 description: "Roblox Open Cloud REST API for accessing data stores, assets, universes, places, users, groups, subscriptions, and Luau execution from outside the engine or via HttpService. Covers authentication (API keys, OAuth 2.0, avoiding legacy cookie auth), scopes and least-privilege, IP allowlists, key rotation and the 60-day auto-expiry rule, Secrets stores, the HttpService-callable subset and its rate limits, webhooks, and in-engine vs Open Cloud decision tree. Use for external automation, CI/CD, bulk data, scheduled snapshots, and cross-experience tooling."
-last_reviewed: 2026-07-16
+last_reviewed: 2026-07-20
 ---
 
 # roblox-open-cloud
@@ -99,6 +99,8 @@ Base URL: `https://apis.roblox.com/cloud/v2/...` (plus a few `apis.roblox.com/<f
 - `ListDataStoreEntries`, `CreateDataStoreEntry`, `GetDataStoreEntry`, `UpdateDataStoreEntry`, `IncrementDataStoreEntry`, `DeleteDataStoreEntry`.
 - `ListDataStoreEntryRevisions` (version history per entry).
 - Scoped variants under `/data-stores/{data_store_id}/scopes/{scope}/entries/...`.
+- **Rate limits (v2):** share the experience Data Store request budgets with in-engine APIs (read/write/list/remove scale with concurrent users). See [error codes & limits](https://create.roblox.com/docs/cloud-services/data-stores/error-codes-and-limits#access-limits) and rate-limit external callers (fixed spacing or leaky bucket). Do not assume Open Cloud has a separate unlimited pool.
+- **Legacy v1** (`/datastores/v1/`, `/ordered-data-stores/v1/`): after July 29, 2026 the fixed non-scaling tables on the [throttling guide](https://create.roblox.com/docs/cloud/guides/data-stores/throttling) apply only to those legacy paths.
 
 **Memory stores** (`/cloud/v2/universes/{universe_id}/memory-stores/...`):
 - Sorted maps: `ListMemoryStoreSortedMapItems`, `CreateMemoryStoreSortedMapItem`, `GetMemoryStoreSortedMapItem`, `UpdateMemoryStoreSortedMapItem`, `DeleteMemoryStoreSortedMapItem`.
@@ -107,6 +109,7 @@ Base URL: `https://apis.roblox.com/cloud/v2/...` (plus a few `apis.roblox.com/<f
 
 **Ordered data stores** (`/cloud/v2/universes/{universe_id}/ordered-data-stores/...`):
 - `ListOrderedDataStoreEntries`, `CreateOrderedDataStoreEntry`, `GetOrderedDataStoreEntry`, `UpdateOrderedDataStoreEntry`, `IncrementOrderedDataStoreEntry`, `DeleteOrderedDataStoreEntry`.
+- Same shared experience budget model as standard Data Stores v2 (see error-codes page).
 
 ### Universes & places
 
@@ -246,6 +249,7 @@ Open Cloud emits webhooks for certain events, including **subscription** events 
 - Storing API keys in scripts or source control.
 - Using a personal account's key for group automation (compromises all your resources if the key leaks).
 - Hitting the 2500-req/min `HttpService` Open Cloud limit by not batching.
+- Running bulk Open Cloud v2 Data Store jobs without a client-side rate limiter (shared experience budget → live servers throttle).
 - Expecting `..` in data store keys to work from `HttpService` (it doesn't).
 - Forgetting the 60-day auto-expiry and having automation silently break.
 - Using Open Cloud for things the in-engine API already does (unnecessary external dependency and latency).
@@ -267,6 +271,8 @@ Open Cloud emits webhooks for certain events, including **subscription** events 
 - https://create.roblox.com/docs/cloud/auth/oauth2-overview
 - https://create.roblox.com/docs/en-us/cloud-services/http-service
 - https://create.roblox.com/docs/en-us/cloud/reference/rate-limits
+- https://create.roblox.com/docs/cloud-services/data-stores/error-codes-and-limits (Open Cloud v2 Data Store shared budgets)
+- https://create.roblox.com/docs/cloud/guides/data-stores/throttling (legacy v1 Data Store limits)
 - https://create.roblox.com/docs/en-us/cloud/webhooks/webhook-notifications
 - https://create.roblox.com/docs/en-us/cloud-services/secrets
 


### PR DESCRIPTION
## Summary
- Re-verified suite claims against Creator Docs changes listed in #16
- **Content fixes (datastores + open-cloud):** experience request bases → `300 + concurrentUsers × N`; storage → `500 MB + 1 MB × lifetime users` on compressed latest-version size; Open Cloud v2 shares the experience Data Store budget with game servers; legacy v1 keeps fixed limits after 2026-07-29
- **No suite claim changes** for Animation Graph property renames, AnimationTrack parameter API docs, Pathfinding/Teleport/Audio YAML sample/deprecation-message churn, DevEx tax portal, or Roblox Plus private-server payout wording (suite does not assert those details)

## Test plan
- [x] `node site/scripts/validate-content.mjs` — Content OK
- [x] Grep for stale `250 +`, `100 MB`, independent Open Cloud rate-pool claims
- [ ] CI validate workflow on PR

Closes #16